### PR TITLE
Fix issue requiring 'fileutils' when running on case sensitive file systems

### DIFF
--- a/ocunit2junit.rb
+++ b/ocunit2junit.rb
@@ -26,7 +26,7 @@ TEST_REPORTS_FOLDER = "test-reports"
 ################################################################
 
 require 'time'
-require 'FileUtils'
+require 'fileutils'
 require 'socket'
 
 class ReportParser


### PR DESCRIPTION
'FileUtils' won't be found when running on a case sensitive file system, this removes the camelcasing to ensure it's found
