### PR TITLE
Replace invalid characters in the input that cause the script to fail

### DIFF
--- a/bin/ocunit2junit
+++ b/bin/ocunit2junit
@@ -47,6 +47,8 @@ class ReportParser
   
   def parse_input
     @piped_input.each do |piped_row|
+      piped_row.encode!('UTF-16', 'UTF-8', :invalid => :replace, :replace => '')
+      piped_row.encode!('UTF-8', 'UTF-16')
       puts piped_row
       
       description_results = piped_row.scan(/\s\'(.+)\'\s/)


### PR DESCRIPTION
I've found that exceptions generated by KVO problems in my unit tests sometimes create non-ASCII characters.

OCUnit2JUnit does not handle these gracefully and simply fails with a Ruby exception.

This patch prevents the script from failing when it encounters non-ASCII characters by converting them to UTF-8.
