### PR TITLE
Support Ruby 1.8.7, but without supporting invalid characters

### DIFF
--- a/bin/ocunit2junit
+++ b/bin/ocunit2junit
@@ -47,8 +47,10 @@ class ReportParser
   
   def parse_input
     @piped_input.each do |piped_row|
-      piped_row.encode!('UTF-16', 'UTF-8', :invalid => :replace, :replace => '')
-      piped_row.encode!('UTF-8', 'UTF-16')
+      if piped_row.respond_to?("encode!")
+        piped_row.encode!('UTF-16', 'UTF-8', :invalid => :replace, :replace => '')
+        piped_row.encode!('UTF-8', 'UTF-16')
+      end
       puts piped_row
       
       description_results = piped_row.scan(/\s\'(.+)\'\s/)


### PR DESCRIPTION
I haven't run into the issue that dcutting reported in Pull Request #11, but his fix breaks ocunit2junit on Ruby 1.8.7 (default version shipping with OS X)

A better solution would be to figure out how to support all Ruby versions, but this at least allows the script to run.
