### PR TITLE
Allow TEST_REPORTS_FOLDER to be in a folder that doesn't already exist

### DIFF
--- a/bin/ocunit2junit
+++ b/bin/ocunit2junit
@@ -39,7 +39,7 @@ class ReportParser
     @exit_code = 0
     
     FileUtils.rm_rf(TEST_REPORTS_FOLDER)
-    FileUtils.mkdir(TEST_REPORTS_FOLDER)
+    FileUtils.mkdir_p(TEST_REPORTS_FOLDER)
     parse_input
   end
 


### PR DESCRIPTION
Changing mkdir to mkdir_p, which will create the full path to TEST_REPORTS_FOLDER, instead of only creating the last directory on the path.
