### PR TITLE
handle Kiwi 2.x

### DIFF
--- a/bin/ocunit2junit
+++ b/bin/ocunit2junit
@@ -170,8 +170,18 @@ class ReportParser
   end
 
   def get_test_case_name(test_case, description)
+    # Kiwi 1.x
     if SUPPORT_KIWI and test_case == "example" and !description.nil?
       description
+    # Kiwi 2.x
+    elsif SUPPORT_KIWI && test_case =~ /(.+_)+(Should.+)(_.+)*/
+      test_case.gsub(/([A-Z])([A-Z][a-z]+)/, ' \1 \2')
+               .gsub(/([A-Z][a-z]+)/, ' \1')
+               .gsub(/([A-Z][A-Z]+)/, ' \1')
+               .gsub(/([^A-Za-z ]+)/, ' \1')
+               .gsub(/\s+/, ' ')
+               .split(" _ ")[1..-1].join(", ")
+               .downcase.capitalize
     else
       test_case
     end


### PR DESCRIPTION
Results come through like `Test Case '-[NameOfTestFile NameOfTestFile_TextOfContext_TextOfNestedContext_TextOfShould]' passed (0.008 seconds).`, and should come out of `get_test_case_name` like `Text of context, text of nested context, text of should`. Attempts to detect which version of Kiwi they are using, and handle accordingly.

Seems to work on my project, but I'd feel more comfortable if I wrote some unit tests -- would it be wise to move `ReportParser` out of `bin/ocunit2junit` and into its own class?
