### PR TITLE
Support Ruby 1.9+ (specifically 2.X)

### DIFF
--- a/bin/ocunit2junit
+++ b/bin/ocunit2junit
@@ -46,7 +46,7 @@ class ReportParser
   private
   
   def parse_input
-    @piped_input.each do |piped_row|
+    @piped_input.each_line do |piped_row|
       if piped_row.respond_to?("encode!")
         temporary_encoding = (RUBY_VERSION == '1.9.2') ? 'UTF-8' : 'UTF-16'
         piped_row.encode!(temporary_encoding, 'UTF-8', :invalid => :replace, :replace => '')


### PR DESCRIPTION
Fixing an issue with string.each not being defined in ruby 1.9+.  Changing to use string.each_line per the ruby documentation: http://ruby-doc.org/core-1.9.3/String.html
