### PR TITLE
Support Getting Input From Text File

### DIFF
--- a/bin/ocunit2junit
+++ b/bin/ocunit2junit
@@ -46,7 +46,13 @@ class ReportParser
   private
   
   def parse_input
-    @piped_input.each do |piped_row|
+    if @piped_input.respond_to?(:each)
+        line_enumerator = @piped_input.each
+    elsif @piped_input.respond_to?(:each_line)
+        line_enumerator = @piped_input.each_line
+    end
+
+    line_enumerator.each do |piped_row|
       if piped_row.respond_to?("encode!")
         temporary_encoding = (RUBY_VERSION == '1.9.2') ? 'UTF-8' : 'UTF-16'
         piped_row.encode!(temporary_encoding, 'UTF-8', :invalid => :replace, :replace => '')

--- a/test/test_basic.rb
+++ b/test/test_basic.rb
@@ -23,6 +23,13 @@ class BasicTests < Test::Unit::TestCase
            "The TestProject should be parsed in a TEST-TestProjectTests.xml report"
   end
 
+  def test_output_log_to_reports_dir
+    Helper.pipe_xcodebuild_log_to_ocunit2junit
+
+    assert File.directory?(Helper.test_reports_output_path),
+           "Test reports driven from a log should be written to a 'test-reports' directory"
+  end
+
   def test_report_content
     Helper.pipe_xcodebuild_to_ocunit2junit
     file = File.new Helper.test_reports_output_path + '/TEST-TestProjectTests.xml'
@@ -59,6 +66,15 @@ class BasicTests < Test::Unit::TestCase
       ocunit2junit = abs_file_path + '/../bin/ocunit2junit'
       xcodeproj = abs_file_path + '/TestProject/TestProject.xcodeproj'
       `pushd #{TEST_PATH}; xcodebuild -project #{xcodeproj} -scheme TestProject test | #{ocunit2junit}; popd`
+    end
+
+    def self.pipe_xcodebuild_log_to_ocunit2junit
+      abs_file_path = File.expand_path(File.dirname(__FILE__))
+      ocunit2junit = abs_file_path + '/../bin/ocunit2junit'
+      xcodeproj = abs_file_path + '/TestProject/TestProject.xcodeproj'
+      outputFile = abs_file_path + 'output.log'
+      `pushd #{TEST_PATH}; xcodebuild -project #{xcodeproj} -scheme TestProject test > #{outputFile}; cat #{outputFile} | #{ocunit2junit}; popd`
+      `rm #{outputFile}`
     end
 
   end


### PR DESCRIPTION
If recieving xcode output from a file, need to add support for using 'each_line' instead of 'each' for ruby 1.9+.

As of ruby 1.9.X, String#each is no longer supported - documentation: http://ruby-doc.org/core-1.9.3/String.html

Also added a unit test to highlight the problem and show the fix.

This is an improvement over the pull request #25 , as the actual problem was only partially the ruby version - the other issue was due to having a need to read the xcode output from a file, instead of directly from xcodebuild.
