### PR TITLE
update the script to handle crashed app/tests but XCUnit continues...

### DIFF
--- a/bin/ocunit2junit
+++ b/bin/ocunit2junit
@@ -2,13 +2,13 @@
 #
 # ocunit2junit.rb was written by Christian Hedin <christian.hedin@jayway.com>
 # Version: 0.1 - 30/01 2010
-# Usage: 
+# Usage:
 # xcodebuild -yoursettings | ocunit2junit.rb
 # All output is just passed through to stdout so you don't miss a thing!
 # JUnit style XML-report are put in the folder specified below.
 #
 # Known problems:
-# * "Errors" are not cought, only "warnings".
+# * "Errors" Some are caught but you get a double count +1 for error and +1 for failure.
 # * It's not possible to click links to failed test in Hudson
 # * It's not possible to browse the source code in Hudson
 #
@@ -33,24 +33,31 @@ require 'socket'
 class ReportParser
 
   attr_reader :exit_code
-  
+
   def initialize(piped_input)
     @piped_input = piped_input
     @exit_code = 0
-    
+
     FileUtils.rm_rf(TEST_REPORTS_FOLDER)
     FileUtils.mkdir_p(TEST_REPORTS_FOLDER)
     parse_input
   end
 
   private
-  
+
   def parse_input
     if @piped_input.respond_to?(:each)
-        line_enumerator = @piped_input.each
+      line_enumerator = @piped_input.each
     elsif @piped_input.respond_to?(:each_line)
-        line_enumerator = @piped_input.each_line
+      line_enumerator = @piped_input.each_line
     end
+
+    started = false
+    this_test=""
+    previous_test=""
+    previous_test_case_duration = 0
+    previous_error_location = ""
+    test_suite = ""
 
     line_enumerator.each do |piped_row|
       if piped_row.respond_to?("encode!")
@@ -59,14 +66,14 @@ class ReportParser
         piped_row.encode!('UTF-8', temporary_encoding)
       end
       puts piped_row
-      
+
       description_results = piped_row.scan(/\s\'(.+)\'\s/)
       if description_results && description_results[0] && description_results[0]
         description = description_results[0][0]
       end
-      
+
       case piped_row
-        
+
         when /Test Suite '(\S+)'.*started at\s+(.*)/
           t = Time.parse($2.to_s)
           handle_start_test_suite(t)
@@ -74,56 +81,76 @@ class ReportParser
 
         when /Test Suite '(\S+)'.*finished at\s+(.*)./
           t = Time.parse($2.to_s)
-          handle_end_test_suite($1,t)     
-        
+          handle_end_test_suite($1,t)
+
         when /Test Suite '(\S+)'.*passed at\s+(.*)./
           t = Time.parse($2.to_s)
-          handle_end_test_suite($1,t) 
-        
+          handle_end_test_suite($1,t)
+
         when /Test Suite '(\S+)'.*failed at\s+(.*)./
           t = Time.parse($2.to_s)
-          handle_end_test_suite($1,t) 
-        
+          handle_end_test_suite($1,t)
+
         when /Test Case '-\[\S+\s+(\S+)\]' started./
           test_case = $1
+          # we want to know if we encounter another "started" before we encounter a pass/fail.
+          # #Let's assume this is an error as perhaps a crash occurred on the previous test but XCTest recovered as it can in some cases where you're testing an SDK.
+          if started == true
+            error_message = "ERROR reported by ocunit2junit: Test appears to have started but never finished! Check to see if perhaps a crash occurred in your app/test but XCTest kept going?"
+            handle_test_error(previous_test,error_message,previous_error_location,0)
+            started = false #reset now that we handled the unexpected error.
+          else
+            started = true
+            previous_test = get_test_case_name($1, @last_description)
+            previous_error_location = $1 #TODO: Why this? Here it's same as previous_test
+          end
           @last_description = nil
+          @all_tests[test_case] = test_case
 
         when /Test Case '-\[\S+\s+(\S+)\]' passed \((.*) seconds\)/
           test_case = get_test_case_name($1, @last_description)
           test_case_duration = $2.to_f
+          started = false
           handle_test_passed(test_case,test_case_duration)
 
         when /(.*): error: -\[(\S+) (\S+)\] : (.*)/
           error_location = $1
           test_suite = $2
           error_message = $4
-	        test_case = get_test_case_name($3, description)
-	        handle_test_error(test_suite,test_case,error_message,error_location)
-	        
+          started = false
+          test_case = get_test_case_name($3, description)
+          handle_test_error(test_case,error_message,error_location, 0)
+
         when /Test Case '-\[\S+ (\S+)\]' failed \((\S+) seconds\)/
           test_case = get_test_case_name($1, @last_description)
           test_case_duration = $2.to_f
+          started = false
           handle_test_failed(test_case,test_case_duration)
-	        
+
         when /failed with exit code (\d+)/
+          started = false
           @exit_code = $1.to_i
-          
+
         when
-          /BUILD FAILED/
+        /BUILD FAILED/
+          started = false
           @exit_code = -1;
+
       end
-      
+
       if description
         @last_description = description
       end
     end
   end
-  
+
   def handle_start_test_suite(start_time)
     @total_failed_test_cases = 0
     @total_passed_test_cases = 0
+    @total_errored_test_cases = 0
     @tests_results = Hash.new # test_case -> duration
     @errors = Hash.new  # test_case -> error_msg
+    @all_tests = Hash.new  #all test cases, whether passed, failed, errored are stored here.
     @ended_current_test_suite = false
     @cur_start_time = start_time
   end
@@ -134,21 +161,23 @@ class ReportParser
       host_name = string_to_xml Socket.gethostname
       test_name = string_to_xml test_name
       test_duration = (end_time - @cur_start_time).to_s
-      total_tests = @total_failed_test_cases + @total_passed_test_cases
-      suite_info = '<testsuite errors="0" failures="'+@total_failed_test_cases.to_s+'" hostname="'+host_name+'" name="'+test_name+'" tests="'+total_tests.to_s+'" time="'+test_duration.to_s+'" timestamp="'+end_time.to_s+'">'
+      total_tests = @total_failed_test_cases + @total_passed_test_cases +@total_errored_test_cases
+      suite_info = '<testsuite errors="'+@total_errored_test_cases.to_s+'" failures="'+@total_failed_test_cases.to_s+'" hostname="'+host_name+'" name="'+test_name+'" tests="'+total_tests.to_s+'" time="'+test_duration.to_s+'" timestamp="'+end_time.to_s+'">'
       current_file << "<?xml version='1.0' encoding='UTF-8' ?>\n"
-      current_file << suite_info
-      @tests_results.each do |t|
+      current_file << suite_info + "\n"
+
+      #@tests_results.each do |t|
+      @all_tests.each do |t|
         test_case = string_to_xml t[0]
         duration = @tests_results[test_case]
-        current_file << "<testcase classname='#{test_name}' name='#{test_case}' time='#{duration.to_s}'"
+        current_file << "<testcase classname='#{test_name}' name='#{test_case}' time='#{duration.nil? ? 0 : duration.to_s}'"
         unless @errors[test_case].nil?
           # uh oh we got a failure
           puts "tests_errors[0]"
           puts @errors[test_case][0]
           puts "tests_errors[1]"
           puts @errors[test_case][1]
-          
+
           message = string_to_xml @errors[test_case][0].to_s
           location = string_to_xml @errors[test_case][1].to_s
           current_file << ">\n"
@@ -167,20 +196,24 @@ class ReportParser
   def string_to_xml(s)
     s.gsub(/&/, '&amp;').gsub(/'/, '&quot;').gsub(/</, '&lt;')
   end
-  
+
   def handle_test_passed(test_case,test_case_duration)
     @total_passed_test_cases += 1
     @tests_results[test_case] = test_case_duration
   end
 
-  def handle_test_error(test_suite,test_case,error_message,error_location)
+  def handle_test_error(test_case,error_message,error_location,test_case_duration)
+    @total_errored_test_cases += 1
     # Only record the first error for a test_case
     if @errors[test_case].nil?
       @errors[test_case] = [ error_message, error_location ]
     end
+
+    # Also put it in the test results, else at log writout time, it's not accounted for.
+    @tests_results[test_case] = test_case_duration
   end
 
-  def handle_test_failed(test_case,test_case_duration) 
+  def handle_test_failed(test_case,test_case_duration)
     @total_failed_test_cases +=1
     @tests_results[test_case] = test_case_duration
   end
@@ -189,20 +222,20 @@ class ReportParser
     # Kiwi 1.x
     if SUPPORT_KIWI && test_case == "example" && description
       description
-    # Kiwi 2.x
+      # Kiwi 2.x
     elsif SUPPORT_KIWI && test_case =~ /(.+_)+(Should.+)(_.+)*/
       test_case.gsub(/([A-Z])([A-Z][a-z]+)/, ' \1 \2')
-               .gsub(/([A-Z][a-z]+)/, ' \1')
-               .gsub(/([A-Z][A-Z]+)/, ' \1')
-               .gsub(/([^A-Za-z ]+)/, ' \1')
-               .gsub(/\s+/, ' ')
-               .split(" _ ")[1..-1].join(", ")
-               .downcase.capitalize
+          .gsub(/([A-Z][a-z]+)/, ' \1')
+          .gsub(/([A-Z][A-Z]+)/, ' \1')
+          .gsub(/([^A-Za-z ]+)/, ' \1')
+          .gsub(/\s+/, ' ')
+          .split(" _ ")[1..-1].join(", ")
+          .downcase.capitalize
     else
       test_case
     end
   end
- 
+
 end
 
 #Main


### PR DESCRIPTION
If a test starts, but does not complete, hence there is no Test Case "error", "failed" or "passed" stanza to matched the "started" stanza, then OCUnit2Junit would not report this errant test. If XCUnit continues to run (as it sometimes will do) then the test failure will be ignored. If all further downstream tests have passed, then then the build may get reported as stable, when otherwise it should not. This PR hopefully deals with that.

Note, that we also are counting the errors now, but in the case where a test has an error and a failure, it's double counted as an error and a failure. 
@ciryon Can you please review that part of the code with extra scrutiny?

Thanks@
