### PR TITLE
Fixtest

### DIFF
--- a/test/TestProject/TestProject.xcodeproj/project.pbxproj
+++ b/test/TestProject/TestProject.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		492FBE0315CECD7B00878766 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 492FBE0215CECD7B00878766 /* Foundation.framework */; };
 		492FBE0615CECD7B00878766 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 492FBE0515CECD7B00878766 /* main.m */; };
 		492FBE0A15CECD7B00878766 /* TestProject.1 in CopyFiles */ = {isa = PBXBuildFile; fileRef = 492FBE0915CECD7B00878766 /* TestProject.1 */; };
-		492FBE1715CECD9800878766 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 492FBE1615CECD9800878766 /* SenTestingKit.framework */; };
 		492FBE1915CECD9800878766 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 492FBE1815CECD9800878766 /* Cocoa.framework */; };
 		492FBE2315CECD9800878766 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 492FBE2115CECD9800878766 /* InfoPlist.strings */; };
 		492FBE2615CECD9800878766 /* TestProjectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 492FBE2515CECD9800878766 /* TestProjectTests.m */; };
@@ -35,8 +34,7 @@
 		492FBE0515CECD7B00878766 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		492FBE0815CECD7B00878766 /* TestProject-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TestProject-Prefix.pch"; sourceTree = "<group>"; };
 		492FBE0915CECD7B00878766 /* TestProject.1 */ = {isa = PBXFileReference; lastKnownFileType = text.man; path = TestProject.1; sourceTree = "<group>"; };
-		492FBE1515CECD9800878766 /* TestProjectTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestProjectTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
-		492FBE1615CECD9800878766 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
+		492FBE1515CECD9800878766 /* TestProjectTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestProjectTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		492FBE1815CECD9800878766 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		492FBE1B15CECD9800878766 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		492FBE1C15CECD9800878766 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
@@ -60,7 +58,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				492FBE1715CECD9800878766 /* SenTestingKit.framework in Frameworks */,
 				492FBE1915CECD9800878766 /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -82,7 +79,7 @@
 			isa = PBXGroup;
 			children = (
 				492FBDFE15CECD7B00878766 /* TestProject */,
-				492FBE1515CECD9800878766 /* TestProjectTests.octest */,
+				492FBE1515CECD9800878766 /* TestProjectTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -91,7 +88,6 @@
 			isa = PBXGroup;
 			children = (
 				492FBE0215CECD7B00878766 /* Foundation.framework */,
-				492FBE1615CECD9800878766 /* SenTestingKit.framework */,
 				492FBE1815CECD9800878766 /* Cocoa.framework */,
 				492FBE1A15CECD9800878766 /* Other Frameworks */,
 			);
@@ -172,7 +168,6 @@
 				492FBE1015CECD9800878766 /* Sources */,
 				492FBE1115CECD9800878766 /* Frameworks */,
 				492FBE1215CECD9800878766 /* Resources */,
-				492FBE1315CECD9800878766 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -180,8 +175,8 @@
 			);
 			name = TestProjectTests;
 			productName = TestProjectTests;
-			productReference = 492FBE1515CECD9800878766 /* TestProjectTests.octest */;
-			productType = "com.apple.product-type.bundle";
+			productReference = 492FBE1515CECD9800878766 /* TestProjectTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -189,7 +184,8 @@
 		492FBDF515CECD7B00878766 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0440;
+				LastTestingUpgradeCheck = 0720;
+				LastUpgradeCheck = 0940;
 			};
 			buildConfigurationList = 492FBDF815CECD7B00878766 /* Build configuration list for PBXProject "TestProject" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -219,22 +215,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		492FBE1315CECD9800878766 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		492FBDFA15CECD7B00878766 /* Sources */ = {
@@ -271,14 +251,32 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -287,7 +285,9 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = YES;
@@ -299,17 +299,36 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
@@ -338,12 +357,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"";
+				FRAMEWORK_SEARCH_PATHS = (
+					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+					"$(inherited)",
+				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "TestProjectTests/TestProjectTests-Prefix.pch";
 				INFOPLIST_FILE = "TestProjectTests/TestProjectTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.ocunit2junit.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Debug;
 		};
@@ -351,12 +373,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = "\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"";
+				FRAMEWORK_SEARCH_PATHS = (
+					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+					"$(inherited)",
+				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "TestProjectTests/TestProjectTests-Prefix.pch";
 				INFOPLIST_FILE = "TestProjectTests/TestProjectTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.ocunit2junit.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Release;
 		};
@@ -379,6 +404,7 @@
 				492FBE0F15CECD7B00878766 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		492FBE2815CECD9800878766 /* Build configuration list for PBXNativeTarget "TestProjectTests" */ = {
 			isa = XCConfigurationList;
@@ -387,6 +413,7 @@
 				492FBE2A15CECD9800878766 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/test/TestProject/TestProject.xcodeproj/xcshareddata/xcschemes/TestProject.xcscheme
+++ b/test/TestProject/TestProject.xcodeproj/xcshareddata/xcschemes/TestProject.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0440"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,17 +23,17 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "492FBE1415CECD9800878766"
-               BuildableName = "TestProjectTests.octest"
+               BuildableName = "TestProjectTests.xctest"
                BlueprintName = "TestProjectTests"
                ReferencedContainer = "container:TestProject.xcodeproj">
             </BuildableReference>
@@ -48,17 +48,21 @@
             ReferencedContainer = "container:TestProject.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "492FBDFD15CECD7B00878766"
@@ -71,12 +75,13 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "492FBDFD15CECD7B00878766"

--- a/test/TestProject/TestProjectTests/TestProjectTests-Info.plist
+++ b/test/TestProject/TestProjectTests/TestProjectTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.github.ocunit2junit.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/test/TestProject/TestProjectTests/TestProjectTests.m
+++ b/test/TestProject/TestProjectTests/TestProjectTests.m
@@ -1,19 +1,19 @@
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface TestProjectTests : SenTestCase
+@interface TestProjectTests : XCTestCase
 @end
 
 @implementation TestProjectTests
 
 - (void)testSuccess
 {
-    STAssertEquals(2 + 2, 4, @"Arithmetic FTW");
+    XCTAssertEqual(2 + 2, 4, @"Arithmetic FTW");
 }
 
 - (void)testFail
 {
-    STFail(@"It's easy to write failing tests");
-    STFail(@"Some tests have multiple failures");
+    XCTFail(@"It's easy to write failing tests");
+    XCTFail(@"Some tests have multiple failures");
 }
 
 @end

--- a/test/test_basic.rb
+++ b/test/test_basic.rb
@@ -44,7 +44,7 @@ class BasicTests < Test::Unit::TestCase
     assert report.root.elements['//failure'].size == 1,
            "The TEST-TestProjectTests.xml report should have one <failure/> element"
 
-    assert_equal 'It&quot;s easy to write failing tests',
+    assert_equal 'failed - It&quot;s easy to write failing tests',
            report.root.elements['//failure'].attribute('message').to_s,
            "The TEST-TestProjectTests.xml report should include the first failure message"
   end


### PR DESCRIPTION
Because I create a pull request for the first time, there may be a lack of information to submit. If you have any missing information here, please let me know the information.

I am using OCUnit 2 JUnit at work. I would like to add functionality to this product. For the moment, I'd like to make it possible to run existing tests with the new Xcode 9.4.

Run Test
```
ruby test/test_basic.rb 
```

Output
```
Ignoring bigdecimal-1.3.2 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.2
Ignoring bigdecimal-1.3.1 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.1
Ignoring libxml-ruby-3.0.0 because its extensions are not built.  Try: gem pristine libxml-ruby --version 3.0.0
Ignoring nokogiri-1.6.7.2 because its extensions are not built.  Try: gem pristine nokogiri --version 1.6.7.2
Ignoring psych-2.2.4 because its extensions are not built.  Try: gem pristine psych --version 2.2.4
Ignoring psych-2.0.17 because its extensions are not built.  Try: gem pristine psych --version 2.0.17
Loaded suite test/test_basic
Started
2018-08-10 14:33:39.797 xcodebuild[92541:2186489] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/LNXcodeSupport.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:33:39.798 xcodebuild[92541:2186489] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/ClangFormat.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:33:39.799 xcodebuild[92541:2186489] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/Alcatraz.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:33:40.254 xcodebuild[92541:2186493]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
/var/folders/fl/s47g5c7s2h5bxyr5tf2z0xr00000gn/T/com.apple.dt.XCTest/IDETestRunSession-97D271F2-7225-4047-BA04-01289C3B32A5/TestProjectTests-C603D964-FC6A-4881-9A3B-15565712939C/Session-TestProjectTests-2018-08-10_143340-O9pRyI.log
2018-08-10 14:33:40.254 xcodebuild[92541:2186489] [MT] IDETestOperationsObserverDebug: (DDA1CA29-BF1E-4960-9DF5-95C39F6A98BE) Beginning test session TestProjectTests-DDA1CA29-BF1E-4960-9DF5-95C39F6A98BE at 2018-08-10 14:33:40.255 with Xcode 9F2000 on target <DVTLocalComputer: 0x7f9a01765ce0 (My Mac | x86_64h)> (10.13.6 (17G65))
** TEST FAILED **

Ignoring bigdecimal-1.3.2 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.2
Ignoring bigdecimal-1.3.1 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.1
.Ignoring bigdecimal-1.3.2 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.2
Ignoring bigdecimal-1.3.1 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.1
2018-08-10 14:33:42.270 xcodebuild[92558:2186682] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/LNXcodeSupport.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:33:42.271 xcodebuild[92558:2186682] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/ClangFormat.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:33:42.271 xcodebuild[92558:2186682] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/Alcatraz.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:33:42.729 xcodebuild[92558:2186686]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
/var/folders/fl/s47g5c7s2h5bxyr5tf2z0xr00000gn/T/com.apple.dt.XCTest/IDETestRunSession-33527A9F-A75B-4853-ACD2-53EAA3F4731F/TestProjectTests-464F0F5C-9753-4C00-9487-1CD67E7C6418/Session-TestProjectTests-2018-08-10_143342-UChJZo.log
2018-08-10 14:33:42.731 xcodebuild[92558:2186682] [MT] IDETestOperationsObserverDebug: (8CEABA97-49EA-4724-B6A8-5981136776F8) Beginning test session TestProjectTests-8CEABA97-49EA-4724-B6A8-5981136776F8 at 2018-08-10 14:33:42.730 with Xcode 9F2000 on target <DVTLocalComputer: 0x7f831973d600 (My Mac | x86_64h)> (10.13.6 (17G65))
** TEST FAILED **

.Ignoring bigdecimal-1.3.2 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.2
Ignoring bigdecimal-1.3.1 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.1
2018-08-10 14:33:44.141 xcodebuild[92573:2186783] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/LNXcodeSupport.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:33:44.142 xcodebuild[92573:2186783] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/ClangFormat.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:33:44.142 xcodebuild[92573:2186783] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/Alcatraz.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:33:44.561 xcodebuild[92573:2186788]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
/var/folders/fl/s47g5c7s2h5bxyr5tf2z0xr00000gn/T/com.apple.dt.XCTest/IDETestRunSession-7F22C29B-A256-4563-A598-4416B5CA1F98/TestProjectTests-100C0A1B-6FC1-4418-8A4C-E2C37E8CEF5A/Session-TestProjectTests-2018-08-10_143344-RmYnhC.log
2018-08-10 14:33:44.561 xcodebuild[92573:2186783] [MT] IDETestOperationsObserverDebug: (80EE4E2A-126B-4CCD-80E6-4B7A811B1E94) Beginning test session TestProjectTests-80EE4E2A-126B-4CCD-80E6-4B7A811B1E94 at 2018-08-10 14:33:44.561 with Xcode 9F2000 on target <DVTLocalComputer: 0x7fee39035ca0 (My Mac | x86_64h)> (10.13.6 (17G65))
** TEST FAILED **

.
Finished in 6.133272 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------
3 tests, 7 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------
0.49 tests/s, 1.14 assertions/s
YasueKizuki-no-MacBook-Air:OCUnit2JUnit admin$ ruby test/test_basic.rb 
Ignoring bigdecimal-1.3.2 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.2
Ignoring bigdecimal-1.3.1 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.1
Ignoring libxml-ruby-3.0.0 because its extensions are not built.  Try: gem pristine libxml-ruby --version 3.0.0
Ignoring nokogiri-1.6.7.2 because its extensions are not built.  Try: gem pristine nokogiri --version 1.6.7.2
Ignoring psych-2.2.4 because its extensions are not built.  Try: gem pristine psych --version 2.2.4
Ignoring psych-2.0.17 because its extensions are not built.  Try: gem pristine psych --version 2.0.17
Loaded suite test/test_basic
Started
2018-08-10 14:34:12.581 xcodebuild[92592:2187213] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/LNXcodeSupport.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:34:12.583 xcodebuild[92592:2187213] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/ClangFormat.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:34:12.584 xcodebuild[92592:2187213] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/Alcatraz.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:34:13.100 xcodebuild[92592:2187248]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
/var/folders/fl/s47g5c7s2h5bxyr5tf2z0xr00000gn/T/com.apple.dt.XCTest/IDETestRunSession-4722DD4A-121E-4641-B44A-67F0E99B217A/TestProjectTests-CF1A0A8B-A679-42C2-9983-F87A24B56234/Session-TestProjectTests-2018-08-10_143413-56T3RF.log
2018-08-10 14:34:13.100 xcodebuild[92592:2187213] [MT] IDETestOperationsObserverDebug: (54622DAE-03F8-4016-B736-D85A5D696CB7) Beginning test session TestProjectTests-54622DAE-03F8-4016-B736-D85A5D696CB7 at 2018-08-10 14:34:13.100 with Xcode 9F2000 on target <DVTLocalComputer: 0x7febdc72bf20 (My Mac | x86_64h)> (10.13.6 (17G65))
** TEST FAILED **

Ignoring bigdecimal-1.3.2 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.2
Ignoring bigdecimal-1.3.1 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.1
.Ignoring bigdecimal-1.3.2 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.2
Ignoring bigdecimal-1.3.1 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.1
2018-08-10 14:34:15.023 xcodebuild[92609:2187341] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/LNXcodeSupport.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:34:15.024 xcodebuild[92609:2187341] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/ClangFormat.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:34:15.024 xcodebuild[92609:2187341] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/Alcatraz.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:34:15.485 xcodebuild[92609:2187360]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
/var/folders/fl/s47g5c7s2h5bxyr5tf2z0xr00000gn/T/com.apple.dt.XCTest/IDETestRunSession-8BBE0772-7AD5-4F6F-9A64-D0E3852D9EC9/TestProjectTests-3BCED3A2-3205-44B3-9ACF-984272D66609/Session-TestProjectTests-2018-08-10_143415-K1NZbG.log
2018-08-10 14:34:15.485 xcodebuild[92609:2187341] [MT] IDETestOperationsObserverDebug: (BB435DBB-D027-41A8-9FAF-39DF1FE2C92E) Beginning test session TestProjectTests-BB435DBB-D027-41A8-9FAF-39DF1FE2C92E at 2018-08-10 14:34:15.485 with Xcode 9F2000 on target <DVTLocalComputer: 0x7fa9adf5ef70 (My Mac | x86_64h)> (10.13.6 (17G65))
** TEST FAILED **

.Ignoring bigdecimal-1.3.2 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.2
Ignoring bigdecimal-1.3.1 because its extensions are not built.  Try: gem pristine bigdecimal --version 1.3.1
2018-08-10 14:34:16.916 xcodebuild[92624:2187435] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/LNXcodeSupport.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:34:16.917 xcodebuild[92624:2187435] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/ClangFormat.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:34:16.917 xcodebuild[92624:2187435] [MT] PluginLoading: Required plug-in compatibility UUID 426A087B-D3AA-431A-AFDF-F135EC00DE1C for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/Alcatraz.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2018-08-10 14:34:17.341 xcodebuild[92624:2187438]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
/var/folders/fl/s47g5c7s2h5bxyr5tf2z0xr00000gn/T/com.apple.dt.XCTest/IDETestRunSession-9FC7AD6A-9B7B-4EAE-A457-534CDDF1C743/TestProjectTests-9122432D-974D-4290-BE9A-5C568DA5D460/Session-TestProjectTests-2018-08-10_143417-cb2S1m.log
2018-08-10 14:34:17.341 xcodebuild[92624:2187435] [MT] IDETestOperationsObserverDebug: (19996184-AD5C-4AC3-89B0-09B55BE06702) Beginning test session TestProjectTests-19996184-AD5C-4AC3-89B0-09B55BE06702 at 2018-08-10 14:34:17.342 with Xcode 9F2000 on target <DVTLocalComputer: 0x7fb55a620350 (My Mac | x86_64h)> (10.13.6 (17G65))
** TEST FAILED **

.
Finished in 6.39931 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------
3 tests, 7 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------
0.47 tests/s, 1.09 assertions/s
```